### PR TITLE
Solve issue with shell's special characters (#7)

### DIFF
--- a/sgbd/mysql.sqlexec
+++ b/sgbd/mysql.sqlexec
@@ -1,7 +1,7 @@
 {
     "sql_exec": {
         "options": ["-f", "--table"],
-        "args": "-h{options.host} -P{options.port} -u{options.username} -p{options.password} -D{options.database}",
+        "args": "-h{options.host} -P{options.port} -u\"{options.username}\" -p\"{options.password}\" -D\"{options.database}\"",
         "queries": {
             "desc" : {
                 "query": "show tables",

--- a/sgbd/pgsql.sqlexec
+++ b/sgbd/pgsql.sqlexec
@@ -1,7 +1,7 @@
 {
     "sql_exec": {
         "options": [],
-        "args": "-h {options.host} -p {options.port} -U {options.username} -d {options.database}",
+        "args": "-h {options.host} -p {options.port} -U \"{options.username}\" -d \"{options.database}\"",
         "queries": {
             "desc" : {
                 "query": "\\dt",


### PR DESCRIPTION
Solve the error that occurs when your settings contain one or more
characters that are considered as special characters by the shell. This
characters should be escaped or the command could fail or execute with
unexpected results.

This problem is described in issue #7

The proposed solution involves surrounding parameters that could contain
special characters with double quotes ("). This parameters / settings
are: user name, password and database name (you can create a user and a
database that contain special characters - on the other hand, I believe
it is not possible to have those special characters as a host name).

TODO: I haven't tested postgresql command because I don't have it
installed at this moment.

TODO 2: I don't have experience with oracle, so I didn't know how to
change the connection arguments or even if it was necessary.
