### PR TITLE
add backticks to quote table names

### DIFF
--- a/sgbd/mysql.sqlexec
+++ b/sgbd/mysql.sqlexec
@@ -9,12 +9,12 @@
                 "format" : "|%s|"
             },
             "desc table": {
-                "query": "desc %s",
+                "query": "desc `%s`",
                 "options": ["-f", "--table"],
                 "format" : "|%s|"
             },
             "show records": {
-                "query": "select * from %s limit 100",
+                "query": "select * from `%s` limit 100",
                 "options": ["-f", "--table"],
                 "format" : "|%s|"
             }


### PR DESCRIPTION
If given table name matches a MySQL keyword, a backtick is necessary.
