### PR TITLE
Suport for multiple schemas and quoted table names (#13)

### DIFF
--- a/sgbd/pgsql.sqlexec
+++ b/sgbd/pgsql.sqlexec
@@ -5,12 +5,12 @@
         "args": "-h {options.host} -p {options.port} -U \"{options.username}\" -d \"{options.database}\"",
         "queries": {
             "desc" : {
-                "query": "\\dt",
+                "query": "SELECT '| '||quote_ident(n.nspname)||'.'|| quote_ident(c.relname)||' |' AS tblname FROM pg_catalog.pg_class AS c INNER JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace WHERE relkind = 'r' AND n.nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema') ORDER BY pg_catalog.pg_table_is_visible(c.oid) DESC, n.nspname, c.relname",
                 "options": ["-t"],
                 "format" : "|%s|"
             },
             "desc table": {
-                "query": "\\d %s",
+                "query": "\\d+ %s",
                 "options": [],
                 "format" : "|%s|"
             },


### PR DESCRIPTION
Added support for multiple schemas in PostgreSQL.
This also fixes problem with "show table records" and "desc table", which were not working with quoted table names like these "MyTable".
