### PR TITLE
Fix for missing "before" dict item.

### DIFF
--- a/sgbd/vertica.sqlexec
+++ b/sgbd/vertica.sqlexec
@@ -1,6 +1,7 @@
 {
     "sql_exec": {
         "options": [],
+        "before" : [],
         "args": "-h {options.host} -p {options.port} -U \"{options.username}\" -w \"{options.password}\" -d \"{options.database}\"",
         "queries": {
             "desc" : {


### PR DESCRIPTION
Vertica connections were broken because the vertica sgdb file was missing the "before" dict item. This fixes it.