### PR TITLE
config support for MsSQL

### DIFF
--- a/SQLExec.sublime-settings
+++ b/SQLExec.sublime-settings
@@ -5,6 +5,7 @@
         "pgsql"  : "psql",
         "oracle" : "sqlplus",
         "vertica": "vsql",
+        "mssql"  : "~/bin/mssql",
     },
     "connections": {
     }

--- a/sgbd/mssql.sqlexec
+++ b/sgbd/mssql.sqlexec
@@ -1,0 +1,24 @@
+{
+    "sql_exec": {
+        "options": ["-f", "table"],
+        "before": [],
+        "args": "mssql -s {options.host} -u {options.username} -p {options.password} -d {options.database} -e ",
+        "queries": {
+            "desc" : {
+                "query": "SELECT Distinct CONCAT('|', TABLE_NAME) FROM information_schema.TABLES",
+                "options": ["-f", "table"],
+                "format" : "|%s|"
+            },
+            "desc table": {
+                "query": "EXEC sp_columns %s",
+                "options": ["-f", "table"],
+                "format" : "|%s|"
+            },
+            "show records": {
+                "query": "SELECT TOP 100 * FROM %s",
+                "options": ["-f", "table"],
+                "format" : "|%s|"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi,
Here are basic config for supporting mssql.

The main culprit now is the `mssql` command, I personally choose to use the node one : https://github.com/patriksimek/node-mssql

It is working quite well but does not support the stdin method, used here:
https://github.com/jum4/sublime-sqlexec/blob/bd35295f6a162c5717675b863f5014a0a57ca185/SQLExec.py#L24

So I made a tiny wrapper for it:
```bash
#!/bin/bash

for line in "`cat`"; do
   /usr/local/bin/mssql $1 $2 $3 $4 $5 $6 $7 $8 $9 ${10} ${11} ${12} ${13} -q "$line"
done
````


It is working well on my mac.
