### PR TITLE
Use spaces in output instead of tabs

### DIFF
--- a/sgbd/oracle.sqlexec
+++ b/sgbd/oracle.sqlexec
@@ -4,7 +4,8 @@
         "before": [
             "set colsep '|'",
             "set pagesize 100",
-            "set linesize 500"
+            "set linesize 500",
+            "set tab off"
         ],
         "args": "{options.username}/{options.password}@(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST={options.host})(PORT={options.port})))(CONNECT_DATA=(SERVICE_NAME={options.service})))",
         "queries": {


### PR DESCRIPTION
Disabled the usage of the tab character on result output from sqlplus, improving readability on ST results pane when tab width is different from 8.
