### PR TITLE
Check if 'password' is in the connection setting and add it

### DIFF
--- a/SQLExec.py
+++ b/SQLExec.py
@@ -113,8 +113,11 @@ class Options:
         self.host     = connections[self.name]['host']
         self.port     = connections[self.name]['port']
         self.username = connections[self.name]['username']
-        self.password = connections[self.name]['password']
         self.database = connections[self.name]['database']
+
+        if 'password' in connections[self.name]:
+            self.password = connections[self.name]['password']
+
         if 'service' in connections[self.name]:
             self.service  = connections[self.name]['service']
 


### PR DESCRIPTION
When not set the "password" in the settings of the connection, it returned:

```
Traceback (most recent call last):
  File "SQLExec in ~/.config/sublime-text-3/Installed Packages/SQLExec.sublime-package", line 140, in sqlChangeConnection
  File "SQLExec in ~/.config/sublime-text-3/Installed Packages/SQLExec.sublime-package", line 120, in __init__
KeyError: 'password'
```

Because it's always requiered, but for `psql` connections is not completly required
