### PR TITLE
added support for sqsh and subprocesses now inherit environment variables

### DIFF
--- a/SQLExec.py
+++ b/SQLExec.py
@@ -83,7 +83,7 @@ class Command:
 
     def run(self):
         sublime.status_message(' SQLExec: running SQL command')
-        results, errors = subprocess.Popen(self.text, stdout=subprocess.PIPE,stderr=subprocess.PIPE, shell=True).communicate()
+        results, errors = subprocess.Popen(self.text, stdout=subprocess.PIPE,stderr=subprocess.PIPE, shell=True, env=os.environ.copy()).communicate()
 
         if not results and errors:
             self._errors(errors.decode('utf-8', 'replace').replace('\r', ''))

--- a/SQLExec.sublime-settings
+++ b/SQLExec.sublime-settings
@@ -1,11 +1,12 @@
 {
-    "sql_exec.debug": false,
-    "sql_exec.commands": {
-        "mysql"  : "mysql",
-        "pgsql"  : "psql",
-        "oracle" : "sqlplus",
-        "vertica": "vsql",
-    },
-    "connections": {
-    }
+		"sql_exec.debug": false,
+		"sql_exec.commands": {
+				"mysql"  : "mysql",
+				"pgsql"  : "psql",
+				"oracle" : "sqlplus",
+				"vertica": "vsql",
+				"sqsh"   : "sqsh",
+		},
+		"connections": {
+		}
 }

--- a/sgbd/sqsh.sqlexec
+++ b/sgbd/sqsh.sqlexec
@@ -1,0 +1,27 @@
+{
+  "sql_exec": {
+    "options": [],
+    "before": ["\\set semicolon_cmd=\"\\go -mpretty -l\""],
+    "args": "-S {options.host}:{options.port} -U\"{options.username}\" -P\"{options.password}\" -D{options.database}",
+    "queries": {
+      "desc": {
+        "query": "select table_name from information_schema.tables order by 1;",
+        "before" :["\\set semicolon_cmd=\"\\go -mpretty -l -h -f\""],
+        "options": [],
+        "format": "|%s|"
+      },
+      "desc table": {
+        "query": "exec sp_columns \"%s\";",
+        "options": [],
+        "before": ["\\set semicolon_cmd=\"\\go -mpretty -l -h -f\""],
+        "format": "|%s|"
+      },
+      "show records": {
+        "query": "select top 100 * from \"%s\";",
+        "options": [],
+        "before": ["\\set semicolon_cmd=\"\\go -mpretty -l -h -f\""],
+        "format": "|%s|"
+      }
+    }
+  }
+}


### PR DESCRIPTION
sqsh (http://sourceforge.net/projects/sqsh/) can now be used
tested on sql server
installed sqsh via Homebrew (which includes freetds)

updated SQLExec.py so that subprocesses inherit environment varaibles