### PR TITLE
Fix for Postgres: Only get password option if it exists

### DIFF
--- a/SQLExec.py
+++ b/SQLExec.py
@@ -117,7 +117,8 @@ class Options:
         self.host     = connections[self.name]['host']
         self.port     = connections[self.name]['port']
         self.username = connections[self.name]['username']
-        self.password = connections[self.name]['password']
+        if 'password' in connections[self.name]:
+            self.password = connections[self.name]['password']
         self.database = connections[self.name]['database']
         if 'service' in connections[self.name]:
             self.service  = connections[self.name]['service']


### PR DESCRIPTION
Since Postgres uses pgpass.conf for passwords, SQLExec.py shouldn't try to load it unless it is present. Because the attribute didn't exist it would silently error and not allow any SQL commands to run. With this change it will only load the password if it is present for the config.
