### PR TITLE
Show active connection on status bar

### DIFF
--- a/SQLExec.py
+++ b/SQLExec.py
@@ -1,7 +1,6 @@
 import sublime, sublime_plugin, tempfile, os, subprocess
 
 connection = None
-active_connection = None
 history = ['']
 
 class Connection:
@@ -136,10 +135,9 @@ class Options:
         return names
 
 def sqlChangeConnection(index):
-    global connection, active_connection
+    global connection
     names = Options.list()
     options = Options(names[index])
-    active_connection = options
     connection = Connection(options)
     sublime.status_message(' SQLExec: switched to %s' % names[index])
     sublime.active_window().active_view().run_command('sql_show_active_connection')
@@ -230,6 +228,8 @@ class sqlShowActiveConnection(sublime_plugin.TextCommand):
         self.status_bar()
 
     def status_bar(self):
-        global active_connection
-        message = 'SQLExec conn : %s ' % active_connection
+        global connection
+        icon = sublime.load_settings("SQLExec.sublime-settings").get('connection_icon') or '\u26A1'
+
+        message =  'SQLExec conn %s : %s ' % (icon, connection.options)
         sublime.active_window().active_view().set_status('sqlexec', message)


### PR DESCRIPTION
User (I'm) often forget which connection is currently active.

After selecting connection, there is no information at all which connection is actually user select.  

This PR will add information for currently active connection (last selected connection) on status bar. As a plus, I add additional customisable icon (in unicode character).